### PR TITLE
Add FirebaseStorage functionality

### DIFF
--- a/lib/application/storage/upload/upload_cubit.dart
+++ b/lib/application/storage/upload/upload_cubit.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:bloc/bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:institute_app/domain/core/value_objects.dart';
+import 'package:institute_app/domain/storage/models/storage_failure.dart';
+import 'package:institute_app/domain/storage/storage_repository_interface.dart';
+
+part 'upload_cubit.freezed.dart';
+part 'upload_state.dart';
+
+@injectable
+class UploadCubit extends Cubit<UploadState> {
+  UploadCubit(StorageRepositoryInterface storageRepositoryInterface)
+      : _storageRepositoryInterface = storageRepositoryInterface,
+        super(const UploadState.initial());
+
+  final StorageRepositoryInterface _storageRepositoryInterface;
+
+  Future<void> uploadFile(File file, String path) async {
+    emit(const UploadState.uploading());
+    final failureOrUrl = await _storageRepositoryInterface.uploadFile(
+      file,
+      path,
+    );
+    failureOrUrl.fold(
+      (f) => emit(UploadState.failed(f)),
+      (url) => emit(UploadState.uploaded(url)),
+    );
+  }
+
+  Future<void> uploadImage(File image) async {
+    emit(const UploadState.uploading());
+    final failureOrUrl = await _storageRepositoryInterface.uploadImage(
+      image,
+    );
+    failureOrUrl.fold(
+      (f) => emit(UploadState.failed(f)),
+      (url) => emit(UploadState.uploaded(url)),
+    );
+  }
+}

--- a/lib/application/storage/upload/upload_cubit.freezed.dart
+++ b/lib/application/storage/upload/upload_cubit.freezed.dart
@@ -1,0 +1,615 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'upload_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$UploadState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() uploading,
+    required TResult Function(Url url) uploaded,
+    required TResult Function(StorageFailure failure) failed,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? uploading,
+    TResult? Function(Url url)? uploaded,
+    TResult? Function(StorageFailure failure)? failed,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? uploading,
+    TResult Function(Url url)? uploaded,
+    TResult Function(StorageFailure failure)? failed,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Initial value) initial,
+    required TResult Function(Uploading value) uploading,
+    required TResult Function(Uploaded value) uploaded,
+    required TResult Function(Failed value) failed,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Initial value)? initial,
+    TResult? Function(Uploading value)? uploading,
+    TResult? Function(Uploaded value)? uploaded,
+    TResult? Function(Failed value)? failed,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Initial value)? initial,
+    TResult Function(Uploading value)? uploading,
+    TResult Function(Uploaded value)? uploaded,
+    TResult Function(Failed value)? failed,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UploadStateCopyWith<$Res> {
+  factory $UploadStateCopyWith(
+          UploadState value, $Res Function(UploadState) then) =
+      _$UploadStateCopyWithImpl<$Res, UploadState>;
+}
+
+/// @nodoc
+class _$UploadStateCopyWithImpl<$Res, $Val extends UploadState>
+    implements $UploadStateCopyWith<$Res> {
+  _$UploadStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<$Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
+      __$$InitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<$Res>
+    extends _$UploadStateCopyWithImpl<$Res, _$InitialImpl>
+    implements _$$InitialImplCopyWith<$Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$InitialImpl implements Initial {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'UploadState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() uploading,
+    required TResult Function(Url url) uploaded,
+    required TResult Function(StorageFailure failure) failed,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? uploading,
+    TResult? Function(Url url)? uploaded,
+    TResult? Function(StorageFailure failure)? failed,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? uploading,
+    TResult Function(Url url)? uploaded,
+    TResult Function(StorageFailure failure)? failed,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Initial value) initial,
+    required TResult Function(Uploading value) uploading,
+    required TResult Function(Uploaded value) uploaded,
+    required TResult Function(Failed value) failed,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Initial value)? initial,
+    TResult? Function(Uploading value)? uploading,
+    TResult? Function(Uploaded value)? uploaded,
+    TResult? Function(Failed value)? failed,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Initial value)? initial,
+    TResult Function(Uploading value)? uploading,
+    TResult Function(Uploaded value)? uploaded,
+    TResult Function(Failed value)? failed,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Initial implements UploadState {
+  const factory Initial() = _$InitialImpl;
+}
+
+/// @nodoc
+abstract class _$$UploadingImplCopyWith<$Res> {
+  factory _$$UploadingImplCopyWith(
+          _$UploadingImpl value, $Res Function(_$UploadingImpl) then) =
+      __$$UploadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UploadingImplCopyWithImpl<$Res>
+    extends _$UploadStateCopyWithImpl<$Res, _$UploadingImpl>
+    implements _$$UploadingImplCopyWith<$Res> {
+  __$$UploadingImplCopyWithImpl(
+      _$UploadingImpl _value, $Res Function(_$UploadingImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$UploadingImpl implements Uploading {
+  const _$UploadingImpl();
+
+  @override
+  String toString() {
+    return 'UploadState.uploading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UploadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() uploading,
+    required TResult Function(Url url) uploaded,
+    required TResult Function(StorageFailure failure) failed,
+  }) {
+    return uploading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? uploading,
+    TResult? Function(Url url)? uploaded,
+    TResult? Function(StorageFailure failure)? failed,
+  }) {
+    return uploading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? uploading,
+    TResult Function(Url url)? uploaded,
+    TResult Function(StorageFailure failure)? failed,
+    required TResult orElse(),
+  }) {
+    if (uploading != null) {
+      return uploading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Initial value) initial,
+    required TResult Function(Uploading value) uploading,
+    required TResult Function(Uploaded value) uploaded,
+    required TResult Function(Failed value) failed,
+  }) {
+    return uploading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Initial value)? initial,
+    TResult? Function(Uploading value)? uploading,
+    TResult? Function(Uploaded value)? uploaded,
+    TResult? Function(Failed value)? failed,
+  }) {
+    return uploading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Initial value)? initial,
+    TResult Function(Uploading value)? uploading,
+    TResult Function(Uploaded value)? uploaded,
+    TResult Function(Failed value)? failed,
+    required TResult orElse(),
+  }) {
+    if (uploading != null) {
+      return uploading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Uploading implements UploadState {
+  const factory Uploading() = _$UploadingImpl;
+}
+
+/// @nodoc
+abstract class _$$UploadedImplCopyWith<$Res> {
+  factory _$$UploadedImplCopyWith(
+          _$UploadedImpl value, $Res Function(_$UploadedImpl) then) =
+      __$$UploadedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Url url});
+}
+
+/// @nodoc
+class __$$UploadedImplCopyWithImpl<$Res>
+    extends _$UploadStateCopyWithImpl<$Res, _$UploadedImpl>
+    implements _$$UploadedImplCopyWith<$Res> {
+  __$$UploadedImplCopyWithImpl(
+      _$UploadedImpl _value, $Res Function(_$UploadedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? url = null,
+  }) {
+    return _then(_$UploadedImpl(
+      null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as Url,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UploadedImpl implements Uploaded {
+  const _$UploadedImpl(this.url);
+
+  @override
+  final Url url;
+
+  @override
+  String toString() {
+    return 'UploadState.uploaded(url: $url)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UploadedImpl &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UploadedImplCopyWith<_$UploadedImpl> get copyWith =>
+      __$$UploadedImplCopyWithImpl<_$UploadedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() uploading,
+    required TResult Function(Url url) uploaded,
+    required TResult Function(StorageFailure failure) failed,
+  }) {
+    return uploaded(url);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? uploading,
+    TResult? Function(Url url)? uploaded,
+    TResult? Function(StorageFailure failure)? failed,
+  }) {
+    return uploaded?.call(url);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? uploading,
+    TResult Function(Url url)? uploaded,
+    TResult Function(StorageFailure failure)? failed,
+    required TResult orElse(),
+  }) {
+    if (uploaded != null) {
+      return uploaded(url);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Initial value) initial,
+    required TResult Function(Uploading value) uploading,
+    required TResult Function(Uploaded value) uploaded,
+    required TResult Function(Failed value) failed,
+  }) {
+    return uploaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Initial value)? initial,
+    TResult? Function(Uploading value)? uploading,
+    TResult? Function(Uploaded value)? uploaded,
+    TResult? Function(Failed value)? failed,
+  }) {
+    return uploaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Initial value)? initial,
+    TResult Function(Uploading value)? uploading,
+    TResult Function(Uploaded value)? uploaded,
+    TResult Function(Failed value)? failed,
+    required TResult orElse(),
+  }) {
+    if (uploaded != null) {
+      return uploaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Uploaded implements UploadState {
+  const factory Uploaded(final Url url) = _$UploadedImpl;
+
+  Url get url;
+  @JsonKey(ignore: true)
+  _$$UploadedImplCopyWith<_$UploadedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$FailedImplCopyWith<$Res> {
+  factory _$$FailedImplCopyWith(
+          _$FailedImpl value, $Res Function(_$FailedImpl) then) =
+      __$$FailedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({StorageFailure failure});
+
+  $StorageFailureCopyWith<$Res> get failure;
+}
+
+/// @nodoc
+class __$$FailedImplCopyWithImpl<$Res>
+    extends _$UploadStateCopyWithImpl<$Res, _$FailedImpl>
+    implements _$$FailedImplCopyWith<$Res> {
+  __$$FailedImplCopyWithImpl(
+      _$FailedImpl _value, $Res Function(_$FailedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? failure = null,
+  }) {
+    return _then(_$FailedImpl(
+      null == failure
+          ? _value.failure
+          : failure // ignore: cast_nullable_to_non_nullable
+              as StorageFailure,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $StorageFailureCopyWith<$Res> get failure {
+    return $StorageFailureCopyWith<$Res>(_value.failure, (value) {
+      return _then(_value.copyWith(failure: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$FailedImpl implements Failed {
+  const _$FailedImpl(this.failure);
+
+  @override
+  final StorageFailure failure;
+
+  @override
+  String toString() {
+    return 'UploadState.failed(failure: $failure)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FailedImpl &&
+            (identical(other.failure, failure) || other.failure == failure));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, failure);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FailedImplCopyWith<_$FailedImpl> get copyWith =>
+      __$$FailedImplCopyWithImpl<_$FailedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() uploading,
+    required TResult Function(Url url) uploaded,
+    required TResult Function(StorageFailure failure) failed,
+  }) {
+    return failed(failure);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? uploading,
+    TResult? Function(Url url)? uploaded,
+    TResult? Function(StorageFailure failure)? failed,
+  }) {
+    return failed?.call(failure);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? uploading,
+    TResult Function(Url url)? uploaded,
+    TResult Function(StorageFailure failure)? failed,
+    required TResult orElse(),
+  }) {
+    if (failed != null) {
+      return failed(failure);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Initial value) initial,
+    required TResult Function(Uploading value) uploading,
+    required TResult Function(Uploaded value) uploaded,
+    required TResult Function(Failed value) failed,
+  }) {
+    return failed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Initial value)? initial,
+    TResult? Function(Uploading value)? uploading,
+    TResult? Function(Uploaded value)? uploaded,
+    TResult? Function(Failed value)? failed,
+  }) {
+    return failed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Initial value)? initial,
+    TResult Function(Uploading value)? uploading,
+    TResult Function(Uploaded value)? uploaded,
+    TResult Function(Failed value)? failed,
+    required TResult orElse(),
+  }) {
+    if (failed != null) {
+      return failed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Failed implements UploadState {
+  const factory Failed(final StorageFailure failure) = _$FailedImpl;
+
+  StorageFailure get failure;
+  @JsonKey(ignore: true)
+  _$$FailedImplCopyWith<_$FailedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/application/storage/upload/upload_state.dart
+++ b/lib/application/storage/upload/upload_state.dart
@@ -1,0 +1,9 @@
+part of 'upload_cubit.dart';
+
+@freezed
+sealed class UploadState with _$UploadState {
+  const factory UploadState.initial() = Initial;
+  const factory UploadState.uploading() = Uploading;
+  const factory UploadState.uploaded(Url url) = Uploaded;
+  const factory UploadState.failed(StorageFailure failure) = Failed;
+}

--- a/lib/data/common/injectable_modules.dart
+++ b/lib/data/common/injectable_modules.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:injectable/injectable.dart';
 
@@ -13,4 +14,7 @@ abstract class FirebaseModules {
 
   @lazySingleton
   FirebaseFirestore get firestore => FirebaseFirestore.instance;
+
+  @lazySingleton
+  FirebaseStorage get firebaseStorage => FirebaseStorage.instance;
 }

--- a/lib/data/storage/storage_repository.dart
+++ b/lib/data/storage/storage_repository.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:injectable/injectable.dart';
+import 'package:institute_app/domain/core/value_objects.dart';
+import 'package:institute_app/domain/storage/models/storage_failure.dart';
+import 'package:institute_app/domain/storage/storage_repository_interface.dart';
+
+@LazySingleton(as: StorageRepositoryInterface)
+class StorageRepository implements StorageRepositoryInterface {
+  const StorageRepository(FirebaseStorage firebaseStorage)
+      : _firebaseStorage = firebaseStorage;
+
+  final FirebaseStorage _firebaseStorage;
+
+  @override
+  Future<Either<StorageFailure, Unit>> deleteFile(String path) {
+    try {
+      _firebaseStorage.ref(path).delete();
+      return Future.value(const Right(unit));
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        return Future.value(
+          const Left(StorageFailure.insufficientPermissions()),
+        );
+      } else if (e.code == 'object-not-found') {
+        return Future.value(const Left(StorageFailure.fileDoesNotExist()));
+      } else {
+        return Future.value(const Left(StorageFailure.unexpected()));
+      }
+    }
+  }
+
+  @override
+  Future<Either<StorageFailure, Unit>> deleteFiles(List<String> paths) {
+    try {
+      for (final path in paths) {
+        _firebaseStorage.ref(path).delete();
+      }
+      return Future.value(const Right(unit));
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        return Future.value(
+          const Left(StorageFailure.insufficientPermissions()),
+        );
+      } else if (e.code == 'object-not-found') {
+        return Future.value(const Left(StorageFailure.fileDoesNotExist()));
+      } else {
+        return Future.value(const Left(StorageFailure.unexpected()));
+      }
+    }
+  }
+
+  @override
+  Future<Either<StorageFailure, Url>> downloadFile(String path) async {
+    try {
+      final url = await _firebaseStorage.ref(path).getDownloadURL();
+      return Future.value(Right(Url(url)));
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        return Future.value(
+          const Left(StorageFailure.insufficientPermissions()),
+        );
+      } else if (e.code == 'object-not-found') {
+        return Future.value(const Left(StorageFailure.fileDoesNotExist()));
+      } else {
+        return Future.value(const Left(StorageFailure.unexpected()));
+      }
+    }
+  }
+
+  @override
+  Future<Either<StorageFailure, Url>> uploadFile(File file, String path) async {
+    try {
+      final uploadTask = _firebaseStorage.ref(path).putFile(file).snapshot;
+      final url = await uploadTask.ref.getDownloadURL();
+      return Future.value(Right(Url(url)));
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        return Future.value(
+          const Left(StorageFailure.insufficientPermissions()),
+        );
+      } else if (e.code == 'object-not-found') {
+        return Future.value(const Left(StorageFailure.fileDoesNotExist()));
+      } else {
+        return Future.value(const Left(StorageFailure.unexpected()));
+      }
+    }
+  }
+
+  @override
+  Future<Either<StorageFailure, Url>> uploadImage(File file) async {
+    try {
+      final reference =
+          _firebaseStorage.ref().child('images/${file.path.split('/').last}');
+      final uploadTask = reference.putFile(file).snapshot;
+      final url = await uploadTask.ref.getDownloadURL();
+      return Future.value(Right(Url(url)));
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        return Future.value(
+          const Left(StorageFailure.insufficientPermissions()),
+        );
+      } else if (e.code == 'object-not-found') {
+        return Future.value(const Left(StorageFailure.fileDoesNotExist()));
+      } else {
+        return Future.value(const Left(StorageFailure.unexpected()));
+      }
+    }
+  }
+}

--- a/lib/domain/storage/models/storage_failure.dart
+++ b/lib/domain/storage/models/storage_failure.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'storage_failure.freezed.dart';
+
+@freezed
+sealed class StorageFailure with _$StorageFailure {
+  const factory StorageFailure.unexpected() = Unexpected;
+  const factory StorageFailure.insufficientPermissions() =
+      InsufficientPermissions;
+  const factory StorageFailure.unableToUpload() = UnableToUpload;
+  const factory StorageFailure.unableToDelete() = UnableToDelete;
+  const factory StorageFailure.fileDoesNotExist() = FileDoesNotExist;
+}

--- a/lib/domain/storage/models/storage_failure.freezed.dart
+++ b/lib/domain/storage/models/storage_failure.freezed.dart
@@ -1,0 +1,702 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'storage_failure.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$StorageFailure {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StorageFailureCopyWith<$Res> {
+  factory $StorageFailureCopyWith(
+          StorageFailure value, $Res Function(StorageFailure) then) =
+      _$StorageFailureCopyWithImpl<$Res, StorageFailure>;
+}
+
+/// @nodoc
+class _$StorageFailureCopyWithImpl<$Res, $Val extends StorageFailure>
+    implements $StorageFailureCopyWith<$Res> {
+  _$StorageFailureCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$UnexpectedImplCopyWith<$Res> {
+  factory _$$UnexpectedImplCopyWith(
+          _$UnexpectedImpl value, $Res Function(_$UnexpectedImpl) then) =
+      __$$UnexpectedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UnexpectedImplCopyWithImpl<$Res>
+    extends _$StorageFailureCopyWithImpl<$Res, _$UnexpectedImpl>
+    implements _$$UnexpectedImplCopyWith<$Res> {
+  __$$UnexpectedImplCopyWithImpl(
+      _$UnexpectedImpl _value, $Res Function(_$UnexpectedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$UnexpectedImpl implements Unexpected {
+  const _$UnexpectedImpl();
+
+  @override
+  String toString() {
+    return 'StorageFailure.unexpected()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UnexpectedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) {
+    return unexpected();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) {
+    return unexpected?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unexpected != null) {
+      return unexpected();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) {
+    return unexpected(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) {
+    return unexpected?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unexpected != null) {
+      return unexpected(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Unexpected implements StorageFailure {
+  const factory Unexpected() = _$UnexpectedImpl;
+}
+
+/// @nodoc
+abstract class _$$InsufficientPermissionsImplCopyWith<$Res> {
+  factory _$$InsufficientPermissionsImplCopyWith(
+          _$InsufficientPermissionsImpl value,
+          $Res Function(_$InsufficientPermissionsImpl) then) =
+      __$$InsufficientPermissionsImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InsufficientPermissionsImplCopyWithImpl<$Res>
+    extends _$StorageFailureCopyWithImpl<$Res, _$InsufficientPermissionsImpl>
+    implements _$$InsufficientPermissionsImplCopyWith<$Res> {
+  __$$InsufficientPermissionsImplCopyWithImpl(
+      _$InsufficientPermissionsImpl _value,
+      $Res Function(_$InsufficientPermissionsImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$InsufficientPermissionsImpl implements InsufficientPermissions {
+  const _$InsufficientPermissionsImpl();
+
+  @override
+  String toString() {
+    return 'StorageFailure.insufficientPermissions()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InsufficientPermissionsImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) {
+    return insufficientPermissions();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) {
+    return insufficientPermissions?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (insufficientPermissions != null) {
+      return insufficientPermissions();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) {
+    return insufficientPermissions(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) {
+    return insufficientPermissions?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (insufficientPermissions != null) {
+      return insufficientPermissions(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class InsufficientPermissions implements StorageFailure {
+  const factory InsufficientPermissions() = _$InsufficientPermissionsImpl;
+}
+
+/// @nodoc
+abstract class _$$UnableToUploadImplCopyWith<$Res> {
+  factory _$$UnableToUploadImplCopyWith(_$UnableToUploadImpl value,
+          $Res Function(_$UnableToUploadImpl) then) =
+      __$$UnableToUploadImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UnableToUploadImplCopyWithImpl<$Res>
+    extends _$StorageFailureCopyWithImpl<$Res, _$UnableToUploadImpl>
+    implements _$$UnableToUploadImplCopyWith<$Res> {
+  __$$UnableToUploadImplCopyWithImpl(
+      _$UnableToUploadImpl _value, $Res Function(_$UnableToUploadImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$UnableToUploadImpl implements UnableToUpload {
+  const _$UnableToUploadImpl();
+
+  @override
+  String toString() {
+    return 'StorageFailure.unableToUpload()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UnableToUploadImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) {
+    return unableToUpload();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) {
+    return unableToUpload?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unableToUpload != null) {
+      return unableToUpload();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) {
+    return unableToUpload(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) {
+    return unableToUpload?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unableToUpload != null) {
+      return unableToUpload(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnableToUpload implements StorageFailure {
+  const factory UnableToUpload() = _$UnableToUploadImpl;
+}
+
+/// @nodoc
+abstract class _$$UnableToDeleteImplCopyWith<$Res> {
+  factory _$$UnableToDeleteImplCopyWith(_$UnableToDeleteImpl value,
+          $Res Function(_$UnableToDeleteImpl) then) =
+      __$$UnableToDeleteImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UnableToDeleteImplCopyWithImpl<$Res>
+    extends _$StorageFailureCopyWithImpl<$Res, _$UnableToDeleteImpl>
+    implements _$$UnableToDeleteImplCopyWith<$Res> {
+  __$$UnableToDeleteImplCopyWithImpl(
+      _$UnableToDeleteImpl _value, $Res Function(_$UnableToDeleteImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$UnableToDeleteImpl implements UnableToDelete {
+  const _$UnableToDeleteImpl();
+
+  @override
+  String toString() {
+    return 'StorageFailure.unableToDelete()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UnableToDeleteImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) {
+    return unableToDelete();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) {
+    return unableToDelete?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unableToDelete != null) {
+      return unableToDelete();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) {
+    return unableToDelete(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) {
+    return unableToDelete?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (unableToDelete != null) {
+      return unableToDelete(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnableToDelete implements StorageFailure {
+  const factory UnableToDelete() = _$UnableToDeleteImpl;
+}
+
+/// @nodoc
+abstract class _$$FileDoesNotExistImplCopyWith<$Res> {
+  factory _$$FileDoesNotExistImplCopyWith(_$FileDoesNotExistImpl value,
+          $Res Function(_$FileDoesNotExistImpl) then) =
+      __$$FileDoesNotExistImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$FileDoesNotExistImplCopyWithImpl<$Res>
+    extends _$StorageFailureCopyWithImpl<$Res, _$FileDoesNotExistImpl>
+    implements _$$FileDoesNotExistImplCopyWith<$Res> {
+  __$$FileDoesNotExistImplCopyWithImpl(_$FileDoesNotExistImpl _value,
+      $Res Function(_$FileDoesNotExistImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$FileDoesNotExistImpl implements FileDoesNotExist {
+  const _$FileDoesNotExistImpl();
+
+  @override
+  String toString() {
+    return 'StorageFailure.fileDoesNotExist()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$FileDoesNotExistImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() unexpected,
+    required TResult Function() insufficientPermissions,
+    required TResult Function() unableToUpload,
+    required TResult Function() unableToDelete,
+    required TResult Function() fileDoesNotExist,
+  }) {
+    return fileDoesNotExist();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? unexpected,
+    TResult? Function()? insufficientPermissions,
+    TResult? Function()? unableToUpload,
+    TResult? Function()? unableToDelete,
+    TResult? Function()? fileDoesNotExist,
+  }) {
+    return fileDoesNotExist?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? unexpected,
+    TResult Function()? insufficientPermissions,
+    TResult Function()? unableToUpload,
+    TResult Function()? unableToDelete,
+    TResult Function()? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (fileDoesNotExist != null) {
+      return fileDoesNotExist();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Unexpected value) unexpected,
+    required TResult Function(InsufficientPermissions value)
+        insufficientPermissions,
+    required TResult Function(UnableToUpload value) unableToUpload,
+    required TResult Function(UnableToDelete value) unableToDelete,
+    required TResult Function(FileDoesNotExist value) fileDoesNotExist,
+  }) {
+    return fileDoesNotExist(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Unexpected value)? unexpected,
+    TResult? Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult? Function(UnableToUpload value)? unableToUpload,
+    TResult? Function(UnableToDelete value)? unableToDelete,
+    TResult? Function(FileDoesNotExist value)? fileDoesNotExist,
+  }) {
+    return fileDoesNotExist?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Unexpected value)? unexpected,
+    TResult Function(InsufficientPermissions value)? insufficientPermissions,
+    TResult Function(UnableToUpload value)? unableToUpload,
+    TResult Function(UnableToDelete value)? unableToDelete,
+    TResult Function(FileDoesNotExist value)? fileDoesNotExist,
+    required TResult orElse(),
+  }) {
+    if (fileDoesNotExist != null) {
+      return fileDoesNotExist(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class FileDoesNotExist implements StorageFailure {
+  const factory FileDoesNotExist() = _$FileDoesNotExistImpl;
+}

--- a/lib/domain/storage/storage_repository_interface.dart
+++ b/lib/domain/storage/storage_repository_interface.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:fpdart/fpdart.dart';
+import 'package:institute_app/domain/core/value_objects.dart';
+import 'package:institute_app/domain/storage/models/storage_failure.dart';
+
+abstract class StorageRepositoryInterface {
+  Future<Either<StorageFailure, Url>> uploadFile(File file, String path);
+  Future<Either<StorageFailure, Url>> uploadImage(File file);
+  Future<Either<StorageFailure, Unit>> deleteFile(String path);
+  Future<Either<StorageFailure, Unit>> deleteFiles(List<String> paths);
+  Future<Either<StorageFailure, Url>> downloadFile(String path);
+}

--- a/lib/injection.config.dart
+++ b/lib/injection.config.dart
@@ -10,26 +10,32 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:cloud_firestore/cloud_firestore.dart' as _i4;
 import 'package:firebase_auth/firebase_auth.dart' as _i3;
+import 'package:firebase_storage/firebase_storage.dart' as _i5;
 import 'package:get_it/get_it.dart' as _i1;
-import 'package:google_sign_in/google_sign_in.dart' as _i5;
+import 'package:google_sign_in/google_sign_in.dart' as _i6;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:institute_app/application/auth/auth_bloc.dart' as _i14;
-import 'package:institute_app/application/user/user_cubit.dart' as _i15;
+import 'package:institute_app/application/auth/auth_bloc.dart' as _i18;
+import 'package:institute_app/application/storage/upload/upload_cubit.dart'
+    as _i11;
+import 'package:institute_app/application/user/user_cubit.dart' as _i19;
 import 'package:institute_app/application/user/user_form/user_form_bloc.dart'
-    as _i16;
-import 'package:institute_app/data/auth/firebase_auth_repo.dart' as _i9;
-import 'package:institute_app/data/common/injectable_modules.dart' as _i17;
-import 'package:institute_app/data/event/event_repository.dart' as _i11;
+    as _i20;
+import 'package:institute_app/data/auth/firebase_auth_repo.dart' as _i13;
+import 'package:institute_app/data/common/injectable_modules.dart' as _i21;
+import 'package:institute_app/data/event/event_repository.dart' as _i15;
 import 'package:institute_app/data/organization/organization_repository.dart'
-    as _i7;
-import 'package:institute_app/data/user/user_repository.dart' as _i13;
-import 'package:institute_app/domain/auth/auth_interface.dart' as _i8;
+    as _i8;
+import 'package:institute_app/data/storage/storage_repository.dart' as _i10;
+import 'package:institute_app/data/user/user_repository.dart' as _i17;
+import 'package:institute_app/domain/auth/auth_interface.dart' as _i12;
 import 'package:institute_app/domain/event/event_repository_interface.dart'
-    as _i10;
+    as _i14;
 import 'package:institute_app/domain/organization/organization_repository_interface.dart'
-    as _i6;
+    as _i7;
+import 'package:institute_app/domain/storage/storage_repository_interface.dart'
+    as _i9;
 import 'package:institute_app/domain/user/user_repository_interface.dart'
-    as _i12;
+    as _i16;
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -45,27 +51,33 @@ extension GetItInjectableX on _i1.GetIt {
     final firebaseModules = _$FirebaseModules();
     gh.lazySingleton<_i3.FirebaseAuth>(() => firebaseModules.firebaseAuth);
     gh.lazySingleton<_i4.FirebaseFirestore>(() => firebaseModules.firestore);
-    gh.lazySingleton<_i5.GoogleSignIn>(() => firebaseModules.googleSignIn);
-    gh.lazySingleton<_i6.OrganizationRepositoryInterface>(() =>
-        _i7.OrganizationRepository(firestore: gh<_i4.FirebaseFirestore>()));
-    gh.lazySingleton<_i8.AuthInterface>(() => _i9.FirebaseAuthRepo(
+    gh.lazySingleton<_i5.FirebaseStorage>(
+        () => firebaseModules.firebaseStorage);
+    gh.lazySingleton<_i6.GoogleSignIn>(() => firebaseModules.googleSignIn);
+    gh.lazySingleton<_i7.OrganizationRepositoryInterface>(() =>
+        _i8.OrganizationRepository(firestore: gh<_i4.FirebaseFirestore>()));
+    gh.lazySingleton<_i9.StorageRepositoryInterface>(
+        () => _i10.StorageRepository(gh<_i5.FirebaseStorage>()));
+    gh.factory<_i11.UploadCubit>(
+        () => _i11.UploadCubit(gh<_i9.StorageRepositoryInterface>()));
+    gh.lazySingleton<_i12.AuthInterface>(() => _i13.FirebaseAuthRepo(
           firebaseAuth: gh<_i3.FirebaseAuth>(),
-          googleSignIn: gh<_i5.GoogleSignIn>(),
+          googleSignIn: gh<_i6.GoogleSignIn>(),
         ));
-    gh.lazySingleton<_i10.EventRepositoryInterface>(
-        () => _i11.EventRepository(firestore: gh<_i4.FirebaseFirestore>()));
-    gh.lazySingleton<_i12.UserRepositoryInterface>(() => _i13.UserRepository(
-          authRepo: gh<_i8.AuthInterface>(),
+    gh.lazySingleton<_i14.EventRepositoryInterface>(
+        () => _i15.EventRepository(firestore: gh<_i4.FirebaseFirestore>()));
+    gh.lazySingleton<_i16.UserRepositoryInterface>(() => _i17.UserRepository(
+          authRepo: gh<_i12.AuthInterface>(),
           firestore: gh<_i4.FirebaseFirestore>(),
         ));
-    gh.factory<_i14.AuthBloc>(
-        () => _i14.AuthBloc(authInterface: gh<_i8.AuthInterface>()));
-    gh.factory<_i15.UserCubit>(
-        () => _i15.UserCubit(gh<_i12.UserRepositoryInterface>()));
-    gh.factory<_i16.UserFormBloc>(
-        () => _i16.UserFormBloc(gh<_i12.UserRepositoryInterface>()));
+    gh.factory<_i18.AuthBloc>(
+        () => _i18.AuthBloc(authInterface: gh<_i12.AuthInterface>()));
+    gh.factory<_i19.UserCubit>(
+        () => _i19.UserCubit(gh<_i16.UserRepositoryInterface>()));
+    gh.factory<_i20.UserFormBloc>(
+        () => _i20.UserFormBloc(gh<_i16.UserRepositoryInterface>()));
     return this;
   }
 }
 
-class _$FirebaseModules extends _i17.FirebaseModules {}
+class _$FirebaseModules extends _i21.FirebaseModules {}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import cloud_firestore
 import firebase_auth
 import firebase_core
+import firebase_storage
 import google_sign_in_ios
 import path_provider_foundation
 import url_launcher_macos
@@ -16,6 +17,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,6 +361,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      sha256: "75e6cb6bed65138b5bbd86bfd7cf9bc9a175fb0c31aacc400e9203df117ffbe6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.6.0"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      sha256: "545a3a8edf337850403bb0fa03c8074a53deb87c0107d19755c77a82ce07919e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.3"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      sha256: ee6870ff79aa304b8996ba18a4aefe1e8b3fc31fd385eab6574180267aa8d393
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.17"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   fast_immutable_collections: ^10.0.0
   firebase_auth: ^4.16.0
   firebase_core: ^2.24.2
+  firebase_storage: ^11.6.0
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3


### PR DESCRIPTION
This pull request adds the necessary code to implement FirebaseStorage functionality in the project. It includes the addition of the `firebase_storage` package, the creation of the `StorageFailure` and `StorageRepositoryInterface` classes, and the implementation of the `StorageRepository` class.